### PR TITLE
confirmation_message null error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -87,14 +87,14 @@ const GravityFormForm = ({
                 }
 
                 if (status === 'success') {
-                    const { confirmation_message } = data?.data
+                    const { message } = data?.data
 
                     const { confirmations } = singleForm
 
                     const confirmation = confirmations?.find(el => el.isDefault)
 
                     setConfirmationMessage(
-                        confirmation_message || confirmation?.message || false
+                        message || confirmation?.message || false
                     )
 
                     successCallback({


### PR DESCRIPTION
With the latest version `gatsby-source-gravityforms` getting this error and to fix this I added a patch to change "confirmation_message" to "message"